### PR TITLE
Add support for Slimefun Soulbound

### DIFF
--- a/GraveStonesPlus/Resources/plugin.yml
+++ b/GraveStonesPlus/Resources/plugin.yml
@@ -4,11 +4,9 @@ main: com.bencodez.gravestonesplus.GraveStonesPlus
 description: Description
 author: BenCodez
 api-version: 1.13
-softdepend:
-- Vault
 libraries:
   - org.openjdk.nashorn:nashorn-core:15.3
-softdepend: [ProtocolLib, Vault, PvPManager, WorldGuard, WorldGuardExtraFlags]
+softdepend: [ProtocolLib, Vault, PvPManager, WorldGuard, WorldGuardExtraFlags, Slimefun]
 commands:
   gravestonesplus:
     description: Main plugin command

--- a/GraveStonesPlus/pom.xml
+++ b/GraveStonesPlus/pom.xml
@@ -256,6 +256,10 @@
 			<id>CodeMC</id>
 			<url>https://repo.codemc.org/repository/maven-public/</url>
 		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -274,6 +278,12 @@
 			<groupId>me.NoChance.PvPManager</groupId>
 			<artifactId>PvPManager</artifactId>
 			<version>3.12</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.Slimefun</groupId>
+			<artifactId>Slimefun4</artifactId>
+			<version>2fd0f8a0d8</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/GraveStonesPlus/src/com/bencodez/gravestonesplus/GraveStonesPlus.java
+++ b/GraveStonesPlus/src/com/bencodez/gravestonesplus/GraveStonesPlus.java
@@ -9,6 +9,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
 
+import com.bencodez.gravestonesplus.pluginhandles.SlimefunHandle;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
@@ -229,6 +230,9 @@ public class GraveStonesPlus extends AdvancedCorePlugin {
 		if (Bukkit.getPluginManager().isPluginEnabled("PvPManager")) {
 			pvpManager = new PvpManagerHandle(this);
 		}
+		if (Bukkit.getPluginManager().isPluginEnabled("Slimefun")) {
+			slimefun = new SlimefunHandle(this);
+		}
 
 		Bukkit.getScheduler().runTaskAsynchronously(plugin, new Runnable() {
 
@@ -273,6 +277,9 @@ public class GraveStonesPlus extends AdvancedCorePlugin {
 
 	@Getter
 	private PvpManagerHandle pvpManager;
+
+	@Getter
+	private SlimefunHandle slimefun;
 
 	public int numberOfGraves(UUID uuid) {
 		int num = 0;

--- a/GraveStonesPlus/src/com/bencodez/gravestonesplus/listeners/PlayerDeathListener.java
+++ b/GraveStonesPlus/src/com/bencodez/gravestonesplus/listeners/PlayerDeathListener.java
@@ -122,7 +122,9 @@ public class PlayerDeathListener implements Listener {
 		for (int i = 0; i < 36; i++) {
 			ItemStack item = inv.getItem(i);
 			if (item != null) {
-				if (keepItemsWithMatchingLore(item, text)) {
+				if (plugin.getSlimefun() != null && plugin.getSlimefun().isSoulBoundItem(item)) {
+					// Slimefun will put items back to player inventory
+                } else if (keepItemsWithMatchingLore(item, text)) {
 					keepItems.put(i, item);
 				} else if (!hasCurseOfVanishing(item)) {
 					itemsWithSlot.put(i, item);
@@ -132,35 +134,45 @@ public class PlayerDeathListener implements Listener {
 
 		// store items outside of player inventory
 		if (inv.getHelmet() != null) {
-			if (keepItemsWithMatchingLore(inv.getHelmet(), text)) {
+			if (plugin.getSlimefun() != null && plugin.getSlimefun().isSoulBoundItem(inv.getHelmet())) {
+				// Slimefun will put items back to player inventory
+			} else if (keepItemsWithMatchingLore(inv.getHelmet(), text)) {
 				keepItems.put(-1, inv.getHelmet());
 			} else if (!hasCurseOfVanishing(inv.getHelmet())) {
 				itemsWithSlot.put(-1, inv.getHelmet());
 			}
 		}
 		if (inv.getChestplate() != null) {
-			if (keepItemsWithMatchingLore(inv.getChestplate(), text)) {
+			if (plugin.getSlimefun() != null && plugin.getSlimefun().isSoulBoundItem(inv.getChestplate())) {
+				// Slimefun will put items back to player inventory
+			} else if (keepItemsWithMatchingLore(inv.getChestplate(), text)) {
 				keepItems.put(-2, inv.getChestplate());
 			} else if (!hasCurseOfVanishing(inv.getChestplate())) {
 				itemsWithSlot.put(-2, inv.getChestplate());
 			}
 		}
 		if (inv.getLeggings() != null) {
-			if (keepItemsWithMatchingLore(inv.getLeggings(), text)) {
+			if (plugin.getSlimefun() != null && plugin.getSlimefun().isSoulBoundItem(inv.getLeggings())) {
+				// Slimefun will put items back to player inventory
+			} else if (keepItemsWithMatchingLore(inv.getLeggings(), text)) {
 				keepItems.put(-3, inv.getLeggings());
 			} else if (!hasCurseOfVanishing(inv.getLeggings())) {
 				itemsWithSlot.put(-3, inv.getLeggings());
 			}
 		}
 		if (inv.getBoots() != null) {
-			if (keepItemsWithMatchingLore(inv.getBoots(), text)) {
+			if (plugin.getSlimefun() != null && plugin.getSlimefun().isSoulBoundItem(inv.getBoots())) {
+				// Slimefun will put items back to player inventory
+			} else if (keepItemsWithMatchingLore(inv.getBoots(), text)) {
 				keepItems.put(-4, inv.getBoots());
 			} else if (!hasCurseOfVanishing(inv.getBoots())) {
 				itemsWithSlot.put(-4, inv.getBoots());
 			}
 		}
 		if (inv.getItemInOffHand() != null) {
-			if (keepItemsWithMatchingLore(inv.getItemInOffHand(), text)) {
+			if (plugin.getSlimefun() != null && plugin.getSlimefun().isSoulBoundItem(inv.getItemInOffHand())) {
+				// Slimefun will put items back to player inventory
+			} else if (keepItemsWithMatchingLore(inv.getItemInOffHand(), text)) {
 				keepItems.put(-5, inv.getItemInOffHand());
 			} else if (!hasCurseOfVanishing(inv.getItemInOffHand())) {
 				itemsWithSlot.put(-5, inv.getItemInOffHand());

--- a/GraveStonesPlus/src/com/bencodez/gravestonesplus/pluginhandles/SlimefunHandle.java
+++ b/GraveStonesPlus/src/com/bencodez/gravestonesplus/pluginhandles/SlimefunHandle.java
@@ -1,0 +1,28 @@
+package com.bencodez.gravestonesplus.pluginhandles;
+
+import com.bencodez.gravestonesplus.GraveStonesPlus;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.core.attributes.Soulbound;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+
+public class SlimefunHandle {
+
+    private GraveStonesPlus plugin;
+    private Slimefun slimefun;
+
+    public SlimefunHandle(GraveStonesPlus plugin) {
+        this.plugin = plugin;
+        // Check if PvPManager is enabled
+        if (Bukkit.getPluginManager().isPluginEnabled("Slimefun")) {
+            slimefun = (Slimefun) Bukkit.getPluginManager().getPlugin("Slimefun");
+            this.plugin.getLogger().info("Slimefun support loaded");
+        }
+    }
+
+    public boolean isSoulBoundItem(ItemStack item) {
+        SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
+        return slimefunItem instanceof Soulbound;
+    }
+}


### PR DESCRIPTION
The Soulbound items in Slimefun will automatically add in the player's inventory after respawning, which can lead to item duplication when used with a GraveStonesPlus (one copy in the inventory and one in the grave). This PR adds a check for Soulbound items, ignoring them if they are soulbound.